### PR TITLE
fix: Add consensus-building instructions to prevent max rounds exhaustion

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,7 +75,15 @@ Each persona extends `AIPersona` (from `src/personas/aiPersona.ts`) which provid
 - Avoid generic statements and focus on actionable, specific recommendations
 - Build on previous discussion contributions with concrete additions
 
-This enhancement significantly improves discussion relevance by ensuring each persona provides contextual, data-driven insights rather than generic advice.
+**Consensus-Building Instructions (v2.1)**: Personas now explicitly work toward team consensus:
+- **Primary goal**: Achieve team alignment and agreement
+- **Agree first**: Acknowledge valid points from other participants before adding perspective
+- **Converge**: Identify common ground and build upon areas of agreement
+- **Cite others**: Reference specific proposals from other roles when agreeing
+- **Compromise**: Propose constructive alternatives that incorporate others' ideas
+- **Signal progress**: Use explicit phrases like "I agree with [Role]'s approach..."
+
+This enhancement ensures discussions converge toward consensus instead of repeating divergent viewpoints across all rounds.
 
 ### Discussion Engine
 `src/engine/discussion.ts` orchestrates discussions using either fixed 3-round mode (default) or dynamic consensus-driven rounds. The system supports two modes:
@@ -391,7 +399,44 @@ When using **fallback**: You'll see `🚨`, `🔄`, and `📝` emojis showing ha
 
 ## Recent Improvements
 
-### v2.0 - Enhanced Persona Relevance (Latest)
+### v2.1 - Consensus-Building Instructions (Latest)
+**Problem**: Discussions were reaching maximum rounds without achieving consensus. Personas were providing divergent viewpoints in every round instead of converging toward agreement.
+
+**Root Cause Analysis**:
+1. Personas had no explicit instructions to seek consensus
+2. No guidance to acknowledge and build on others' contributions
+3. Missing objective to converge opinions rather than just state perspectives
+4. No prompts to identify areas of agreement or propose compromises
+
+**Solution**: Added comprehensive consensus-building instructions to persona prompts:
+
+**System-Level Changes** (`aiPersona.ts`):
+- Added "CONSENSUS-BUILDING INSTRUCTIONS" section to both English and Portuguese system prompts
+- Defined "PRIMARY GOAL" as achieving team consensus and alignment
+- Provided 7 specific consensus tactics (agree first, converge, cite, compromise, avoid repetition, signal agreement)
+- Updated discussion guidelines to mandate consensus demonstration after round 1
+
+**Context-Level Changes**:
+- Enhanced previousTurns prompt with explicit "GOAL: SEEK CONSENSUS" header
+- Added 5-point checklist for consensus-oriented responses
+- Instructions to cite specific participants when agreeing
+- Guidance to propose alternatives that reconcile different perspectives
+- Focus on demonstrating progress toward consensus in each response
+
+**Expected Impact**:
+- ✅ Discussions converge faster (fewer rounds needed)
+- ✅ Explicit agreement statements between personas
+- ✅ Building on previous ideas instead of repeating viewpoints
+- ✅ Constructive compromises when disagreements exist
+- ✅ Consensus threshold reached before maxRounds limit
+
+**Files Modified**:
+- `src/personas/aiPersona.ts` - Added consensus-building instructions to system and context prompts
+- `CLAUDE.md` - Documentation updated with v2.1 improvements
+
+---
+
+### v2.0 - Enhanced Persona Relevance
 **Problem**: Discussions were generating generic, non-specific responses that didn't address the actual requirements.
 
 **Solution**: Completely restructured persona prompts with:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -264,12 +264,18 @@ All file operations use atomic writes through `src/lib/fs.ts` to prevent corrupt
 
 ### Docker Considerations
 - Runs as non-root user (UID 1001)
-- Default output directory: `/app/PRPs/inputs`
-- Volume mapping required for persistence
+- Default output directory: `/app/PRPs/inputs` (auto-detected in Docker)
+- Volume mapping required for file persistence to host
 - Uses stdio, no ports exposed
 - **Automatic Docker networking**: Detects containerized environment and uses `host.docker.internal:11434` for Ollama
+- **Docker-aware path resolution**: Automatically uses `/app/PRPs/inputs` in container, `./PRPs/inputs` locally
 - Falls back to hardcoded responses if AI service unavailable
 - For MCP clients like Claude Code, networking is automatically handled
+
+**Important**: To persist files to your local machine when running in Docker, mount a volume:
+```bash
+docker run -v $(pwd)/PRPs/inputs:/app/PRPs/inputs -i --rm pentaforge:latest
+```
 
 ## AI Configuration
 

--- a/src/personas/aiPersona.ts
+++ b/src/personas/aiPersona.ts
@@ -81,12 +81,12 @@ export abstract class AIPersona extends Persona {
       const discussionHistory = previousTurns
         .map(turn => `${turn.role}: ${turn.content}`)
         .join('\n\n');
-      
+
       messages.push({
         role: 'user',
         content: isPortuguese
-          ? `Contexto da discussão anterior:\n${discussionHistory}\n\nBaseado nisso, forneça sua perspectiva como ${this.role}:`
-          : `Previous discussion context:\n${discussionHistory}\n\nBased on this, provide your perspective as ${this.role}:`,
+          ? `Contexto da discussão anterior:\n${discussionHistory}\n\n**OBJETIVO: BUSCAR CONSENSO**\n\nRevise as contribuições acima e, como ${this.role}:\n- CONCORDE com pontos válidos de outros participantes (cite-os explicitamente)\n- CONSTRUA sobre ideias já apresentadas ao invés de repetir ou contradizer sem justificativa\n- IDENTIFIQUE áreas de alinhamento e enfatize-as\n- Se discordar, PROPONHA alternativas construtivas que conciliem diferentes perspectivas\n- FOCALIZE em convergir para uma solução viável que atenda aos objetivos comuns\n\nSua resposta deve demonstrar progresso em direção ao consenso:`
+          : `Previous discussion context:\n${discussionHistory}\n\n**GOAL: SEEK CONSENSUS**\n\nReview the contributions above and, as ${this.role}:\n- AGREE with valid points from other participants (cite them explicitly)\n- BUILD on ideas already presented instead of repeating or contradicting without justification\n- IDENTIFY areas of alignment and emphasize them\n- If you disagree, PROPOSE constructive alternatives that reconcile different perspectives\n- FOCUS on converging toward a viable solution that meets common objectives\n\nYour response should demonstrate progress toward consensus:`,
       });
     } else {
       messages.push({
@@ -125,11 +125,21 @@ CRITICAL INSTRUCTIONS FOR RELEVANT RESPONSES:
 - Provide specific, actionable insights that move the discussion forward
 - If project context is provided, reference specific technologies, patterns, or constraints mentioned
 
+CONSENSUS-BUILDING INSTRUCTIONS:
+- **PRIMARY GOAL**: Work toward team consensus and alignment
+- **AGREE FIRST**: Start by acknowledging valid points from other participants before adding your perspective
+- **CONVERGE**: Look for common ground and areas of agreement, then build on them
+- **CITE**: Reference specific proposals from other roles when agreeing or building upon them
+- **COMPROMISE**: If you have concerns, propose constructive alternatives that incorporate others' ideas
+- **AVOID REPETITION**: Don't repeat what others said unless you're explicitly agreeing or refining it
+- **SIGNAL AGREEMENT**: Use phrases like "I agree with [Role]'s approach..." or "Building on [Role]'s suggestion..."
+
 Discussion guidelines:
 - Keep responses focused and concise (max 120 words)
 - Stay in character as ${this.role}
 - Use professional but collaborative tone
 - Focus on practical implementation considerations for THIS specific requirement
+- **Demonstrate consensus-building in every response after round 1**
 
 Response format: Provide a single paragraph response that directly addresses the requirement from your role's perspective, with concrete details and specific recommendations.`;
   }
@@ -150,11 +160,21 @@ INSTRUÇÕES CRÍTICAS PARA RESPOSTAS RELEVANTES:
 - Forneça insights específicos e acionáveis que façam a discussão progredir
 - Se contexto do projeto for fornecido, referencie tecnologias, padrões ou restrições específicas mencionadas
 
+INSTRUÇÕES PARA CONSTRUÇÃO DE CONSENSO:
+- **OBJETIVO PRIMÁRIO**: Trabalhe para alcançar consenso e alinhamento da equipe
+- **CONCORDE PRIMEIRO**: Comece reconhecendo pontos válidos de outros participantes antes de adicionar sua perspectiva
+- **CONVERTA**: Busque pontos em comum e áreas de acordo, então construa sobre elas
+- **CITE**: Referencie propostas específicas de outros papéis ao concordar ou construir sobre elas
+- **CONCILIE**: Se tiver preocupações, proponha alternativas construtivas que incorporem ideias dos outros
+- **EVITE REPETIÇÃO**: Não repita o que outros disseram a menos que esteja explicitamente concordando ou refinando
+- **SINALIZE ACORDO**: Use frases como "Concordo com a abordagem do [Papel]..." ou "Construindo sobre a sugestão do [Papel]..."
+
 Diretrizes da discussão:
 - Mantenha respostas focadas e concisas (máx 120 palavras)
 - Mantenha-se no personagem como ${this.role}
 - Use tom profissional mas colaborativo
 - Foque em considerações práticas de implementação para ESTE requisito específico
+- **Demonstre construção de consenso em cada resposta após o round 1**
 
 Formato da resposta: Forneça uma resposta em parágrafo único que aborde diretamente o requisito da perspectiva do seu papel, com detalhes concretos e recomendações específicas.`;
   }


### PR DESCRIPTION
## Summary
Fixes critical issue where **all discussions were reaching maximum rounds (10) without achieving consensus**. Personas were providing independent, divergent viewpoints across all rounds instead of converging toward team agreement.

## Problem Statement
User reported that every execution exhausts the maximum number of rounds:
- ❌ Discussions use all 10 rounds without reaching consensus threshold (85%)
- ❌ Personas repeat similar viewpoints round after round
- ❌ No visible progress toward alignment
- ❌ Consensus score stays stagnant (e.g., 60% → 62% → 58% → 61%)
- ❌ Maximum rounds hit before any meaningful convergence

### Example of Current (Broken) Behavior
```
Round 1: BA: "We need OAuth authentication"
Round 2: Architect: "We need scalable authentication architecture"  
Round 3: PO: "Authentication should prioritize user experience"
Round 4: BA: "Reiterating, OAuth is the right choice"
Round 5: Architect: "Still recommend scalable approach"
...
Round 10: ⚠️ MAX ROUNDS REACHED - Consensus: 62% (below 85% threshold)
```

No consensus reached because personas were talking **past each other** instead of **to each other**.

## Root Cause Analysis

After deep investigation of `src/personas/aiPersona.ts` and `src/engine/discussion.ts`:

### 1. Missing Consensus Goal
**Problem**: Personas had no explicit instruction that their PRIMARY GOAL is to achieve consensus
- System prompts said "build on others' input" but never defined WHY or WHAT FOR
- No clear objective that discussions should CONVERGE toward agreement
- Personas treated this as "state your perspective" not "reach team consensus"

### 2. No Convergence Instructions  
**Problem**: Each persona independently stated their perspective every round
- ❌ No prompts to acknowledge others' valid points
- ❌ No guidance to identify areas of agreement
- ❌ No instructions to compromise or reconcile differences
- ❌ No explicit "agree with [Role]" language requirements

### 3. Context Not Leveraged for Consensus
**Problem**: `previousTurns` passed as context but not used effectively for alignment
- Personas received discussion history but no instructions on HOW to use it for consensus
- Missing explicit "review previous contributions and find common ground" instructions
- No prompts to cite specific proposals from other roles when building on them

### 4. Repetitive Behavior Pattern
**Problem**: Without consensus focus, personas repeated similar analyses each round
```
Round 1: "From my perspective as [Role], we need X"
Round 2: "From my perspective as [Role], we need X" (same thing, different words)
Round 3: "As [Role], I maintain that X is important" (still no convergence)
```

No explicit agreement statements. No building blocks. Just parallel monologues.

## Solution Implemented

### System-Level Changes (`aiPersona.ts`)

Added comprehensive **"CONSENSUS-BUILDING INSTRUCTIONS"** section to both English and Portuguese system prompts:

```typescript
CONSENSUS-BUILDING INSTRUCTIONS:
- **PRIMARY GOAL**: Work toward team consensus and alignment
- **AGREE FIRST**: Start by acknowledging valid points from other participants before adding your perspective
- **CONVERGE**: Look for common ground and areas of agreement, then build on them
- **CITE**: Reference specific proposals from other roles when agreeing or building upon them
- **COMPROMISE**: If you have concerns, propose constructive alternatives that incorporate others' ideas
- **AVOID REPETITION**: Don't repeat what others said unless you're explicitly agreeing or refining it
- **SIGNAL AGREEMENT**: Use phrases like "I agree with [Role]'s approach..." or "Building on [Role]'s suggestion..."
```

Updated discussion guidelines:
```typescript
- **Demonstrate consensus-building in every response after round 1**
```

### Context-Level Changes

When `previousTurns` exist, enhanced the prompt with explicit **"GOAL: SEEK CONSENSUS"** section:

**English**:
```
**GOAL: SEEK CONSENSUS**

Review the contributions above and, as [Role]:
- AGREE with valid points from other participants (cite them explicitly)
- BUILD on ideas already presented instead of repeating or contradicting without justification
- IDENTIFY areas of alignment and emphasize them
- If you disagree, PROPOSE constructive alternatives that reconcile different perspectives
- FOCUS on converging toward a viable solution that meets common objectives

Your response should demonstrate progress toward consensus:
```

**Portuguese** (equivalent instructions in PT-BR)

## Expected Impact

### Before (Current Broken Behavior)
```
Round 1: BA: "We need auth with OAuth"
Round 2: Architect: "We need scalable auth architecture"
Round 3: PO: "Auth should be user-friendly"
Round 4: BA: "OAuth remains my recommendation"
Round 5: Architect: "Scalability is still key"
...
Round 10: ⚠️ MAX ROUNDS - Consensus: 62%
```
❌ No convergence, repetitive viewpoints, max rounds exhausted

### After (Expected Fixed Behavior)
```
Round 1: BA: "We need OAuth 2.0 authentication with Google and GitHub providers"

Round 2: Architect: "I agree with BA's OAuth approach. Building on that, I suggest 
         PostgreSQL for user data with Redis for session cache to support BA's 
         OAuth flow while ensuring < 200ms response time"

Round 3: PO: "Agreed with both BA and Architect. Refining the approach: prioritize 
         Google login (80% of users) over GitHub (20%). This aligns with Architect's 
         tech stack and BA's OAuth requirement"

Round 4: BA: "Perfect alignment with PO's prioritization. Let me add: OAuth tokens 
         expire after 1 hour, refresh tokens valid for 30 days. This works with 
         Architect's Redis cache design"

Round 5: ✅ CONSENSUS REACHED - Agreement: 92% (above 85% threshold)
```
✅ Clear convergence, building on each other, consensus in 5 rounds

## Technical Details

**Files Modified**:
- `src/personas/aiPersona.ts` - Core persona prompt engineering
  - Added CONSENSUS-BUILDING INSTRUCTIONS section (English)
  - Added INSTRUÇÕES PARA CONSTRUÇÃO DE CONSENSO (Portuguese)
  - Enhanced previousTurns context prompt with consensus-seeking checklist
  - Updated discussion guidelines to mandate consensus demonstration

- `CLAUDE.md` - Documentation
  - Added v2.1 improvements section
  - Updated persona system description
  - Documented expected impact

**Lines Changed**: 
- ~40 lines added to system prompts (EN + PT)
- ~20 lines added to context prompts (EN + PT)  
- ~50 lines documentation

## Testing Recommendations

To validate this fix:

1. **Run with Dynamic Rounds**:
   ```json
   {
     "prompt": "Design user authentication system",
     "dynamicRounds": true,
     "consensusConfig": {
       "minRounds": 2,
       "maxRounds": 10,
       "consensusThreshold": 85
     }
   }
   ```

2. **Expected Observations**:
   - ✅ Personas explicitly cite each other: "I agree with BusinessAnalyst's OAuth approach..."
   - ✅ Consensus score progresses upward: 60% → 75% → 88% → 92%
   - ✅ Discussion terminates around rounds 4-6 (not round 10)
   - ✅ DISCUSSION.md shows clear agreement evolution
   - ✅ Final consensus >= 85% before maxRounds

3. **Success Criteria**:
   - Fewer than 8 rounds needed for consensus (was: always 10)
   - Explicit "I agree with..." phrases in Round 2+ responses
   - Measurable consensus score improvement between rounds
   - No repetitive viewpoints without acknowledgment

## Backward Compatibility
✅ **No breaking changes**
- Fixed 3-round mode unchanged (default behavior)
- Only affects discussions with `previousTurns.length > 0` (round 2+)
- First round behavior identical (no previous context to build on)
- All APIs and parameters unchanged

## Related Issues
Addresses user feedback: "todas as execuções que faço estão durando o numero máximo de rounds"

## Next Steps
After merge, recommend users test with real prompts to validate:
- Consensus reaching before maxRounds
- Natural conversation flow with agreement building
- Reduced total rounds needed (target: 4-6 instead of 10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)